### PR TITLE
Fix nil interface panic in image service

### DIFF
--- a/image.go
+++ b/image.go
@@ -53,8 +53,8 @@ func (i *image) Edit(provider string, model string, input any, prompt string, op
 }
 
 func (i *image) getReplicateService() (replicate.ReplicateService, error) {
-	if !i.replicateService.IsInitialized() {
-		replicateService, err := replicate.NewReplicateService(os.Getenv("REPLICATE_API_TOKEN"))
+	if i.replicateService == nil || !i.replicateService.IsInitialized() {
+		replicateService, err := replicate.NewReplicateService(os.Getenv(ReplicateAPIToken))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- prevent panic in image service when replicateService is uninitialized

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_687114225ee88332b35a5066a5928a96