### PR TITLE
Add Veo3 integration to Gemini service

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -12,12 +12,14 @@ import (
 const (
 	IMAGEN_3_MODEL = "imagen-3.0-generate-002"
 	FLASH_2_MODEL  = "gemini-2.0-flash-exp-image-generation"
+	VEO_3_MODEL    = "veo-3.0-video-generation"
 )
 
 type GeminiService interface {
 	GenerateImagen3Image(ctx context.Context, prompt string) ([]byte, error)
 	GenerateFlash2Image(ctx context.Context, prompt string) ([]byte, error)
 	GenerateFlashWithImage(ctx context.Context, prompt, imageURL string) ([]byte, error)
+	GenerateVeo3Video(ctx context.Context, prompt string) ([]byte, error)
 }
 
 type geminiService struct {
@@ -68,4 +70,18 @@ func (s *geminiService) GenerateFlashWithImage(ctx context.Context, prompt, imag
 	// ... (implement image download and blob creation)
 	// Then call model.GenerateContent with both prompt and image blob
 	return nil, nil // Implement as needed
+}
+
+func (s *geminiService) GenerateVeo3Video(ctx context.Context, prompt string) ([]byte, error) {
+	model := s.client.GenerativeModel(VEO_3_MODEL)
+	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
+	if err != nil {
+		return nil, err
+	}
+	for _, part := range resp.Candidates[0].Content.Parts {
+		if video, ok := part.(*genai.Blob); ok {
+			return video.Data, nil
+		}
+	}
+	return nil, nil
 }


### PR DESCRIPTION
## Summary
- extend gemini service with Veo3 support
- add `GenerateVeo3Video` method

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68711648c2088332b2361f088e6d4182