### PR TITLE
Add Veo preview video generation

### DIFF
--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -2,17 +2,23 @@ package gemini
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/google/generative-ai-go/genai"
+	aiplatform "google.golang.org/api/aiplatform/v1"
 	"google.golang.org/api/option"
 )
 
 const (
-	IMAGEN_3_MODEL = "imagen-3.0-generate-002"
-	FLASH_2_MODEL  = "gemini-2.0-flash-exp-image-generation"
-	VEO_3_MODEL    = "veo-3.0-video-generation"
+	IMAGEN_3_MODEL      = "imagen-3.0-generate-002"
+	FLASH_2_MODEL       = "gemini-2.0-flash-exp-image-generation"
+	VEO_3_MODEL         = "veo-3.0-video-generation"
+	VEO_3_PREVIEW_MODEL = "veo-3.0-generate-preview"
 )
 
 type GeminiService interface {
@@ -20,6 +26,7 @@ type GeminiService interface {
 	GenerateFlash2Image(ctx context.Context, prompt string) ([]byte, error)
 	GenerateFlashWithImage(ctx context.Context, prompt, imageURL string) ([]byte, error)
 	GenerateVeo3Video(ctx context.Context, prompt string) ([]byte, error)
+	GenerateVeo3PreviewVideo(ctx context.Context, prompt string, firstFrame, lastFrame []byte) ([]byte, error)
 }
 
 type geminiService struct {
@@ -84,4 +91,71 @@ func (s *geminiService) GenerateVeo3Video(ctx context.Context, prompt string) ([
 		}
 	}
 	return nil, nil
+}
+
+// GenerateVeo3PreviewVideo creates a video using the veo-3.0-generate-preview model
+// by providing the first and last frames along with the prompt.
+func (s *geminiService) GenerateVeo3PreviewVideo(ctx context.Context, prompt string, firstFrame, lastFrame []byte) ([]byte, error) {
+	projectID := os.Getenv("GEMINI_PROJECT_ID")
+	svc, err := aiplatform.NewService(ctx, option.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("projects/%s/locations/us-central1/publishers/google/models/%s", projectID, VEO_3_PREVIEW_MODEL)
+
+	req := &aiplatform.GoogleCloudAiplatformV1PredictLongRunningRequest{
+		Instances: []interface{}{
+			map[string]any{
+				"prompt": prompt,
+				"first_frame": map[string]any{
+					"mimeType":           "image/png",
+					"bytesBase64Encoded": base64.StdEncoding.EncodeToString(firstFrame),
+				},
+				"last_frame": map[string]any{
+					"mimeType":           "image/png",
+					"bytesBase64Encoded": base64.StdEncoding.EncodeToString(lastFrame),
+				},
+			},
+		},
+		Parameters: map[string]any{
+			"mime_type": "video/mp4",
+		},
+	}
+
+	op, err := svc.Projects.Locations.Publishers.Models.PredictLongRunning(endpoint, req).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	fetchReq := &aiplatform.GoogleCloudAiplatformV1FetchPredictOperationRequest{OperationName: op.Name}
+	// Poll until the operation is done or context canceled
+	for {
+		opResp, err := svc.Projects.Locations.Publishers.Models.FetchPredictOperation(endpoint, fetchReq).Do()
+		if err != nil {
+			return nil, err
+		}
+		if opResp.Done {
+			var data struct {
+				Response struct {
+					Videos []struct {
+						Bytes string `json:"bytesBase64Encoded"`
+					} `json:"videos"`
+				} `json:"response"`
+			}
+			if err := json.Unmarshal(opResp.Response, &data); err != nil {
+				return nil, err
+			}
+			if len(data.Response.Videos) > 0 {
+				return base64.StdEncoding.DecodeString(data.Response.Videos[0].Bytes)
+			}
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return nil, fmt.Errorf("video generation did not return a result")
 }


### PR DESCRIPTION
## Summary
- add constant for the veo-3.0-generate-preview model
- add GenerateVeo3PreviewVideo API to Gemini service
- implement polling with predictLongRunning and fetchPredictOperation

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68711f61e19483328265c7270376a9d6