### PR TITLE
Add Veo3 video workflow step

### DIFF
--- a/workflow_test.go
+++ b/workflow_test.go
@@ -2,6 +2,7 @@ package genailib
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
@@ -9,9 +10,9 @@ func TestWorkflowGenerate(t *testing.T) {
 	svc := NewWorkflowService()
 	wf := &Workflow{
 		Steps: []WorkflowStep{
-			{ID: "step1", FunctionType: FunctionTypeTextsToText},
-			{ID: "step2", FunctionType: FunctionTypeTextToImage},
-			{ID: "step3", FunctionType: FunctionTypeTextAndImageToImage},
+			{ID: "step1", FunctionType: FunctionTypeTextsToText, Prompt: "hello"},
+			{ID: "step2", FunctionType: FunctionTypeTextToImage, Prompt: "image"},
+			{ID: "step3", FunctionType: FunctionTypeTextAndImageToImage, Prompt: "edit"},
 		},
 	}
 	result, _, err := svc.Generate(context.Background(), wf, nil)
@@ -20,6 +21,28 @@ func TestWorkflowGenerate(t *testing.T) {
 	}
 	if result != "text_and_image_to_image result" {
 		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestWorkflowGenerateVideo(t *testing.T) {
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+	svc := NewWorkflowService()
+	wf := &Workflow{
+		Steps: []WorkflowStep{
+			{
+				ID:           "step1",
+				FunctionType: FunctionTypeTextAndImagesToVideo,
+				Prompt:       "Create a short clip of a cat",
+				FirstImage:   "https://picsum.photos/seed/cat1/256",
+				LastImage:    "https://picsum.photos/seed/cat2/256",
+			},
+		},
+	}
+	_, _, err := svc.Generate(context.Background(), wf, nil)
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `text_and_images_to_video` step type for workflows
- expose Veo3 preview provider constant
- include first/last image fields in workflow steps
- implement Veo3 preview video generation from public image URLs
- update tests for new workflow step requirements

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68735befa09083329e6a15131579c3a2