### PR TITLE
Add Seedance-1-Lite helper

### DIFF
--- a/external/replicate/replicate.go
+++ b/external/replicate/replicate.go
@@ -9,9 +9,24 @@ import (
 	replicate "github.com/replicate/replicate-go"
 )
 
+// Seedance1LiteModel identifies the bytedance/seedance-1-lite model on Replicate.
+const Seedance1LiteModel = "bytedance/seedance-1-lite"
+
 // ReplicateServiceAPI defines the interface for Replicate service operations.
+
 type ReplicateService interface {
 	Run(ctx context.Context, model string, prompt string, options map[string]any) (any, error)
+	// RunSeedance1Lite runs the bytedance/seedance-1-lite model.
+	// Options may include:
+	//  - "image":               string or *replicate.File
+	//  - "last_frame_image":    string or *replicate.File
+	//  - "duration":           int (seconds)
+	//  - "resolution":         string (e.g. "720p")
+	//  - "aspect_ratio":       string (e.g. "16:9")
+	//  - "fps":                int
+	//  - "camera_fixed":       bool
+	//  - "seed":               int
+	RunSeedance1Lite(ctx context.Context, prompt string, options map[string]any) (any, error)
 	IsInitialized() bool
 }
 
@@ -55,6 +70,12 @@ func (r *replicateService) Run(ctx context.Context, model string, prompt string,
 	}
 
 	return output, nil
+}
+
+// RunSeedance1Lite executes the bytedance/seedance-1-lite model on Replicate.
+// See the model's documentation for the supported input options.
+func (r *replicateService) RunSeedance1Lite(ctx context.Context, prompt string, options map[string]any) (any, error) {
+	return r.Run(ctx, Seedance1LiteModel, prompt, options)
 }
 
 func (r *replicateService) IsInitialized() bool {


### PR DESCRIPTION
## Summary
- add a Seedance-1-Lite constant and helper in Replicate service interface
- implement `RunSeedance1Lite` convenience method

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6873de7dcee0833294b09fc7d0711ed9