### PR TITLE
Add seedance-1 workflow support

### DIFF
--- a/external/replicate/replicate.go
+++ b/external/replicate/replicate.go
@@ -9,6 +9,9 @@ import (
 	replicate "github.com/replicate/replicate-go"
 )
 
+// Seedance1Model identifies the bytedance/seedance-1 model on Replicate.
+const Seedance1Model = "bytedance/seedance-1"
+
 // Seedance1LiteModel identifies the bytedance/seedance-1-lite model on Replicate.
 const Seedance1LiteModel = "bytedance/seedance-1-lite"
 
@@ -16,6 +19,17 @@ const Seedance1LiteModel = "bytedance/seedance-1-lite"
 
 type ReplicateService interface {
 	Run(ctx context.Context, model string, prompt string, options map[string]any) (any, error)
+	// RunSeedance1 runs the bytedance/seedance-1 model.
+	// Options may include:
+	//  - "image":               string or *replicate.File
+	//  - "last_frame_image":    string or *replicate.File
+	//  - "duration":           int (seconds)
+	//  - "resolution":         string (e.g. "720p")
+	//  - "aspect_ratio":       string (e.g. "16:9")
+	//  - "fps":                int
+	//  - "camera_fixed":       bool
+	//  - "seed":               int
+	RunSeedance1(ctx context.Context, prompt string, options map[string]any) (any, error)
 	// RunSeedance1Lite runs the bytedance/seedance-1-lite model.
 	// Options may include:
 	//  - "image":               string or *replicate.File
@@ -70,6 +84,12 @@ func (r *replicateService) Run(ctx context.Context, model string, prompt string,
 	}
 
 	return output, nil
+}
+
+// RunSeedance1 executes the bytedance/seedance-1 model on Replicate.
+// See the model's documentation for the supported input options.
+func (r *replicateService) RunSeedance1(ctx context.Context, prompt string, options map[string]any) (any, error) {
+	return r.Run(ctx, Seedance1Model, prompt, options)
 }
 
 // RunSeedance1Lite executes the bytedance/seedance-1-lite model on Replicate.

--- a/workflow.go
+++ b/workflow.go
@@ -3,10 +3,12 @@ package genailib
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/iomodo/gen-ai-lib/external/gemini"
+	"github.com/iomodo/gen-ai-lib/external/replicate"
 	"github.com/pkg/errors"
 )
 
@@ -35,6 +37,7 @@ const (
 	ProviderStabilitySD3                    = "stability-sd3"
 	ProviderFluxSchnell                     = "flux-schnell"
 	ProviderSana                            = "sana"
+	ProviderSeedance1                       = replicate.Seedance1Model
 	ProviderVeo3Preview                     = gemini.VEO_3_PREVIEW_MODEL
 )
 
@@ -155,6 +158,13 @@ func (s *workflowService) processTextAndImagesToVideo(ctx context.Context, step 
 	case ProviderVeo3Preview:
 		svc := gemini.NewGeminiService()
 		return svc.GenerateVeo3PreviewVideoFromURLs(ctx, prompt, firstURL, lastURL)
+	case ProviderSeedance1:
+		svc, err := replicate.NewReplicateService(os.Getenv(ReplicateAPIToken))
+		if err != nil {
+			return nil, err
+		}
+		opts := map[string]any{"image": firstURL, "last_frame_image": lastURL}
+		return svc.RunSeedance1(ctx, prompt, opts)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -180,6 +190,13 @@ func (s *workflowService) processTextAndImageToVideo(ctx context.Context, step W
 	case ProviderVeo3Preview:
 		svc := gemini.NewGeminiService()
 		return svc.GenerateVeo3PreviewVideoWithStartFrameURL(ctx, prompt, firstURL)
+	case ProviderSeedance1:
+		svc, err := replicate.NewReplicateService(os.Getenv(ReplicateAPIToken))
+		if err != nil {
+			return nil, err
+		}
+		opts := map[string]any{"image": firstURL}
+		return svc.RunSeedance1(ctx, prompt, opts)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}


### PR DESCRIPTION
## Summary
- support Bytedance's seedance-1 model via Replicate
- add provider option for seedance-1 in workflows
- add workflow handling for seedance-1 video generation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6873e85496b08332ae7288c5d8bc5ca5