### PR TITLE
Refactor to reduce duplication and simplify video generation

### DIFF
--- a/external/storage/s3.go
+++ b/external/storage/s3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -30,26 +29,11 @@ func NewS3Service(bucketName string) (Storage, error) {
 }
 
 func (s *s3Service) Upload(ctx context.Context, data []byte, objectName string) (string, error) {
-	var objName string
-	if objectName != "" {
-		objName = objectName
-	} else {
-		objName = fmt.Sprintf("object-%s", uuid.New().String())
-	}
-	return uploadToS3(ctx, s.bucketName, objName, data)
-}
+	objName := generateObjectName(objectName)
 
-func uploadToS3(ctx context.Context, bucketName, objectName string, data []byte) (string, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to load AWS config")
-	}
-
-	client := s3.NewFromConfig(cfg)
-
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(bucketName),
-		Key:    aws.String(objectName),
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(objName),
 		Body:   bytes.NewReader(data),
 		ACL:    types.ObjectCannedACLPublicRead,
 	})
@@ -57,6 +41,6 @@ func uploadToS3(ctx context.Context, bucketName, objectName string, data []byte)
 		return "", errors.Wrap(err, "failed to put object")
 	}
 
-	url := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucketName, objectName)
+	url := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", s.bucketName, objName)
 	return url, nil
 }

--- a/external/storage/storage.go
+++ b/external/storage/storage.go
@@ -1,7 +1,20 @@
 package storage
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 type Storage interface {
 	Upload(ctx context.Context, data []byte, objectName string) (string, error)
+}
+
+// generateObjectName returns objectName if provided, otherwise a random UUID-based name.
+func generateObjectName(objectName string) string {
+	if objectName != "" {
+		return objectName
+	}
+	return fmt.Sprintf("object-%s", uuid.New().String())
 }


### PR DESCRIPTION
## Summary
- add helper for object name generation in storage package
- reuse storage clients and simplify Upload implementations
- centralize Gemini video polling logic
- unify WorkflowService video processing via `generateVideo`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68752ddff898833284feaaa68aaf5000