### PR TITLE
Add audio-to-video workflow step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Coming soon: Installation and usage instructions.
 
 The `AppendVideos` function merges two MP4 clips using the `ffmpeg` command-line tool. You must have `ffmpeg` installed and accessible on your system `PATH`.
 The `MergeVideos` function concatenates multiple MP4 clips into one video using `ffmpeg` as well. When used in workflows, the `videos_to_video` step type can combine video results from earlier steps. Reference the step IDs in the `videos` list so later steps can merge their outputs.
+The `AddAudioToVideo` helper attaches an audio track to a video. The new workflow step type `video_and_audio_to_video` can be used to overlay audio on a generated clip.
 
 ## License
 

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -265,3 +265,35 @@ func TestWorkflowSeedanceSingleImageClipsAndMerge(t *testing.T) {
 		t.Fatalf("merged video is empty")
 	}
 }
+
+func TestWorkflowVideoAndAudioToVideo(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+
+	vid, err := createColorVideo("red")
+	if err != nil {
+		t.Fatalf("failed to create video: %v", err)
+	}
+	aud, err := createToneAudio()
+	if err != nil {
+		t.Fatalf("failed to create audio: %v", err)
+	}
+
+	svc := NewWorkflowService()
+	wf := &Workflow{Steps: []WorkflowStep{{ID: "add", FunctionType: FunctionTypeVideoAndAudioToVideo, Video: "vid", Audio: "aud"}}}
+
+	inputs := map[string]any{"vid": vid, "aud": aud}
+
+	result, _, err := svc.Generate(context.Background(), wf, inputs)
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	b, ok := result.([]byte)
+	if !ok {
+		t.Fatalf("expected []byte result, got %T", result)
+	}
+	if len(b) == 0 {
+		t.Fatalf("output video is empty")
+	}
+}


### PR DESCRIPTION
## Summary
- implement `AddAudioToVideo` helper for looping/truncating audio
- support new workflow step type `video_and_audio_to_video`
- add corresponding process logic and fields
- extend tests for video utilities and workflows
- document audio overlay functionality

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68766f4b45248332b67b25247ee47eee